### PR TITLE
Allow reorganize when not configured as Demi-node

### DIFF
--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -1949,10 +1949,8 @@ bool static Reorganize(CTxDB& txdb, CBlockIndex* pindexNew)
         }
     } else {
         // Only accept blocks from a peer if we are a Demi-node or if peer is a Demi-node
-        if (!fDemiPeerRelay(GetRelayPeerAddr) && fDemiNodes) {
-            if (!fDemiSelf) {
-                return error("Reorganize() : Not toggled self as a Demi-node \n Only accepting single-block Peer relays if we are \n");
-            }
+        if (!fDemiPeerRelay(GetRelayPeerAddr) && fDemiNodes && !fDemiSelf) {
+            LogPrintf("Reorganize() : Peer not flagged as Demi-node, continuing with reorganize to follow majority chain\n");
         }
     }
 

--- a/src/util/util.cpp
+++ b/src/util/util.cpp
@@ -1103,7 +1103,8 @@ void BuildConfigFile()
     fprintf(ConfFile, "#89131 version\n");
     fprintf(ConfFile, "listen=1\n");
     fprintf(ConfFile, "server=1\n");
-    fprintf(ConfFile, "deminodes=1\n");
+    // Disable Demi-nodes by default so wallets follow the majority chain
+    fprintf(ConfFile, "deminodes=0\n");
     fprintf(ConfFile, "demimaxdepth=200\n");
     fprintf(ConfFile, "maxconnections=500\n");
     fprintf(ConfFile, "rpcuser=yourusername\n");


### PR DESCRIPTION
## Summary
- prevent Reorganize from rejecting peers not flagged as Demi-nodes
- disable Demi-node mode by default in generated config

## Testing
- `make check` *(fails: No rule to make target 'check')*

------
https://chatgpt.com/codex/tasks/task_e_68b1c90711c8832f8c6557a1891938bd