### PR TITLE
Fix 64-bit formatting in FormatMoney

### DIFF
--- a/src/util/util.cpp
+++ b/src/util/util.cpp
@@ -41,6 +41,7 @@ namespace boost {
 #include <openssl/rand.h>
 #include <openssl/err.h>
 #include <stdarg.h>
+#include <inttypes.h>
 
 #ifdef WIN32
 #ifdef _MSC_VER
@@ -350,7 +351,7 @@ string FormatMoney(int64_t n, bool fPlus)
     int64_t n_abs = (n > 0 ? n : -n);
     int64_t quotient = n_abs/COIN;
     int64_t remainder = n_abs%COIN;
-    string str = strprintf("%d.%08d", quotient, remainder);
+    string str = strprintf("%" PRId64 ".%08" PRId64, quotient, remainder);
 
     // Right-trim excess zeros before the decimal point:
     int nTrim = 0;


### PR DESCRIPTION
## Summary
- use `PRId64` specifiers to format 64-bit values in `FormatMoney`
- include `<inttypes.h>` for `PRId64`

## Testing
- `make check` *(fails: No rule to make target 'check')*
- `g++ -std=c++11 -c src/util/util.cpp -Isrc` *(fails: missing Boost headers)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c87ea3ec832fa607b4b399ad154d